### PR TITLE
Fix mockup_dialog.rb path in step 1

### DIFF
--- a/step1.html
+++ b/step1.html
@@ -39,7 +39,7 @@ You will find that directory in every YaST module and you will soon find why.
 </p>
 <p>
 Inside that directory there are only two files: &quot;clients/mockup.rb&quot;
-and &quot;lib/systemd_journal/mockup_dialog.rb&quot;. The first one is mainly
+and &quot;lib/journalctl/mockup_dialog.rb&quot;. The first one is mainly
 a Ruby script. Whatever code is there, it will be executed right away when
 calling the client. Several old YaST modules contain clients with the
 functionality implemented in-line. This is now considered harmful since it makes


### PR DESCRIPTION
Just a tiny one: I think `mockup_dialog.rb` in step 1 is wrong.

Thanks!
